### PR TITLE
[OpenMP] Add metadata information

### DIFF
--- a/lib/TaffoUtils/Metadata.h
+++ b/lib/TaffoUtils/Metadata.h
@@ -42,6 +42,7 @@
 #define CLONED_FUN_METADATA    "taffo.equivalentChild"
 #define SOURCE_FUN_METADATA    "taffo.sourceFunction"
 #define INDIRECT_METADATA      "taffo.indirectFunction"
+#define OMP_DISABLED_METADATA  "taffo.ompDisabled"
 
 /* Integer which specifies the distance of the metadata from the
  * original annotation as data flow node counts.

--- a/lib/TaffoUtils/Metadata.h
+++ b/lib/TaffoUtils/Metadata.h
@@ -41,6 +41,7 @@
 #define ORIGINAL_FUN_METADATA  "taffo.originalCall"
 #define CLONED_FUN_METADATA    "taffo.equivalentChild"
 #define SOURCE_FUN_METADATA    "taffo.sourceFunction"
+#define INDIRECT_METADATA      "taffo.indirectFunction"
 
 /* Integer which specifies the distance of the metadata from the
  * original annotation as data flow node counts.


### PR DESCRIPTION
Add Metadata information for OpenMP attached to:
- Shared and unsupported variables that must have their conversion disabled
- Functions that are converted into trampolines, and must be re-converted into OpenMP runtime library functions.